### PR TITLE
fix(iOS端 获取消息 - 改为从本地数据库进行): iOS端 获取历史消息 - 改为从本地数据库进行

### DIFF
--- a/ios/easemob/ChatManager.m
+++ b/ios/easemob/ChatManager.m
@@ -213,8 +213,7 @@ RCT_EXPORT_METHOD(loadMessages:(NSString *)params
     NSString *fromId = [allParams objectForKey:@"fromId"];
     int count = [[allParams objectForKey:@"count"] intValue];
     EMMessageSearchDirection searchDirection = [[allParams objectForKey:@"searchDirection"] intValue];
-    [[EMClient sharedClient].chatManager asyncFetchHistoryMessagesFromServer:conversation.conversationId conversationType:type startMessageId:fromId pageSize:count completion:^(EMCursorResult *aResult, EMError *aError) {
-        [conversation loadMessagesStartFromId:fromId count:count searchDirection:searchDirection completion:^(NSArray *aMessages, EMError *error) {
+    [conversation loadMessagesStartFromId:fromId count:count searchDirection:searchDirection completion:^(NSArray *aMessages, EMError *error) {
             NSMutableArray *dicArray = [NSMutableArray array];
             [aMessages enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
                 [dicArray addObject:[obj objectToDictionary]];
@@ -225,7 +224,6 @@ RCT_EXPORT_METHOD(loadMessages:(NSString *)params
                 reject([NSString stringWithFormat:@"%ld", (NSInteger)error.code], error.errorDescription, nil);
             }
         }];
-    }];
 }
 
 RCT_EXPORT_METHOD(fetchHistoryMessagesFromServer:(NSString *)params


### PR DESCRIPTION
--bug=1026947 --user=韩虎 【重庆劲逸建筑工程有限公司】【网页版/手机端】网页端和手机端看到的群聊消息不一致 https://www.tapd.cn/23787791/s/1394331